### PR TITLE
adjust machine_type to ISUCON9 environment

### DIFF
--- a/go-docker-instance/main.tf
+++ b/go-docker-instance/main.tf
@@ -13,7 +13,7 @@ data "template_file" "default" {
 # doc: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance
 resource "google_compute_instance" "default" {
   name          = var.name
-  machine_type  = "n1-standard-1"
+  machine_type  = "n1-standard-2"
   zone          = "asia-northeast1-b"
   tags = ["tag", "isucon10"]
   boot_disk {

--- a/raw-instance/main.tf
+++ b/raw-instance/main.tf
@@ -9,7 +9,7 @@ provider "google" {
 # doc: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance
 resource "google_compute_instance" "default" {
   name          = var.name
-  machine_type  = "n1-standard-1"
+  machine_type  = "n1-standard-2"
   zone          = "asia-northeast1-b"
   tags = ["tag", "isucon10"]
   boot_disk {


### PR DESCRIPTION
実際のISUCON9予選の環境に合わせてvCPU数を2にするため、`machine_type`を`n1-standard-1`から`n1-standard-2`に変更。
途中からCPU1コアだと捌き切れなくなったので、金銭的に可能ならこちらがいいかなと思います。